### PR TITLE
Flatten modal and overlay nodes with flatNodes prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ onBeforeClose | func | called before the modal closes
 className | string | classes to be applied to the modal element
 overlayClassName | string | classes to be applied to the overlay element
 style | shape({ overlay, modal }) | an object with inline styles to be applied to overlay and modal elements
+flatNodes | bool | renders modal and overlay nodes as siblings (by default the modal node is nested inside the overlay)
 
 ---
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -14,6 +14,7 @@ export const Modal = React.createClass({
       overlay: PropTypes.Object
     }),
     open: PropTypes.bool,
+    flatNodes: PropTypes.bool,
     onRequestClose: PropTypes.func.isRequired,
     onBeforeOpen: PropTypes.func,
     onBeforeClose: PropTypes.func
@@ -67,21 +68,41 @@ export const Modal = React.createClass({
     }
   },
   render() {
+    const overlay = (props = {}) => (
+      <div
+        ref={this.getOverlayRef}
+        className={this.props.overlayClassName}
+        style={this.props.style.overlay}
+        onClick={this.handleOverlayClick}
+        {...props}
+      />
+    );
+    const modal = (
+      <div
+        className={this.props.className}
+        style={this.props.style.modal}>
+        {this.props.children}
+      </div>
+    );
+
+    if (!this.props.open) {
+      return null;
+    }
+
+    if (this.props.flatNodes) {
+      return (
+        <div>
+          {overlay()}
+          {modal}
+        </div>
+      );
+    }
+
     return (
       <div>
-        {this.props.open && (
-          <div
-            ref={this.getOverlayRef}
-            className={this.props.overlayClassName}
-            style={this.props.style.overlay}
-            onClick={this.handleOverlayClick}>
-            <div
-              className={this.props.className}
-              style={this.props.style.modal}>
-              {this.props.children}
-            </div>
-          </div>
-        )}
+        {overlay({
+          children: modal
+        })}
       </div>
     );
   }


### PR DESCRIPTION
Gives developers more options on how they style the modal if they can also have the overlay and modal elements as siblings. 
