### PR TITLE
Make WithRoutesComponent just pass through useful props

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ className | string | classes to be applied to the modal element
 overlayClassName | string | classes to be applied to the overlay element
 style | shape({ overlay, modal }) | an object with inline styles to be applied to overlay and modal elements
 
+---
+
 ### `<Page>`
 
 A stateless unstyled component that locks the scroll position of the underlying page.
@@ -65,19 +67,37 @@ prop|type|description
 :---|:---|:---
 locked | bool.isRequired | locks the position of the web page, preventing scrolling beneath the modal
 
+---
+
 ### `<WithRoutesInModal>`
 
 A react-router integration that renders child routes inside a modal.
 
 ```js
+import { Page, Modal } from 'r-modal';
 import { WithRoutesInModal } from 'r-modal/lib/react-router';
+
+const App = props => (
+  <div>
+    <Page>
+      {props.children}
+    </Page>
+    {props.showModal && (
+      <Modal
+        open
+        onRequestClose={props.onModalClose}>
+        {props.modalContents}
+      </Modal>
+    )}
+  </div>
+);
 
 const AppWithRoutesInModal = props => (
   <WithRoutesInModal
     {...props}
     component={App}
   />
-)
+);
 
 <Router>
   <Route path="/" component={AppWithRoutesInModal}>
@@ -93,8 +113,8 @@ import { WithRoutesInModal } from 'r-modal/lib/react-router';
 const BoardWithRoutesInModal = props => (
   <WithRoutesInModal
     {...props}
-    component={Board}
-    returnTo={`/boards/${props.params.id[0]}`}
+    component={App}
+    backgroundLocation={`/boards/${props.params.id[0]}`}
   />
 )
 

--- a/examples/App.js
+++ b/examples/App.js
@@ -1,0 +1,27 @@
+import React, { PropTypes } from 'react';
+import MyPage from './components/MyPage';
+import MyModal from './components/MyModal';
+
+const App = props => (
+  <div>
+    <MyPage>
+      {props.children}
+    </MyPage>
+    {props.showModal && (
+      <MyModal
+        open
+        onRequestClose={props.onModalClose}>
+        {props.modalContent}
+      </MyModal>
+    )}
+  </div>
+);
+
+App.propTypes = {
+  children: PropTypes.node,
+  showModal: PropTypes.bool,
+  onModalClose: PropTypes.func,
+  modalContent: PropTypes.node
+};
+
+export default App;

--- a/examples/index.js
+++ b/examples/index.js
@@ -2,35 +2,30 @@ import React, { PropTypes } from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router, Route, IndexRoute, browserHistory } from 'react-router';
-import store from './store';
-import Index from './components/IndexRoute';
 import { WithRoutesInModal } from 'r-modal/lib/react-router';
-import MyPage from './components/MyPage';
-import MyModal from './components/MyModal';
-
-const App = ({ children }) => (
-  <div>{children}</div>
-);
+import store from './store';
+import App from './App';
+import Index from './components/IndexRoute';
 
 const ModalContent = props => (<div>This is a modal with id: {props.params.id}</div>);
 
 let i = 100;
-const elements = [];
+const boardContent = [];
 while (i > 0) {
-  elements.push(<div key={i}>dummy content</div>);
+  boardContent.push(<div key={i}>dummy content</div>);
   i--;
 }
 
 const Board = props => (
-  <div>{elements}</div>
+  <App {...props}>
+    {boardContent}
+  </App>
 );
 
 const DefaultWithRoutesInModal = props => (
   <WithRoutesInModal
     {...props}
     component={App}
-    page={MyPage}
-    modal={MyModal}
   />
 );
 
@@ -38,9 +33,7 @@ const BoardWithRoutesInModal = props => (
   <WithRoutesInModal
     {...props}
     component={Board}
-    page={MyPage}
-    modal={MyModal}
-    returnTo={`/boards/${props.params.id[0]}`}
+    parentLocation={`/boards/${props.params.id[0]}`}
   />
 );
 

--- a/src/react-router/WithRoutesInModal.js
+++ b/src/react-router/WithRoutesInModal.js
@@ -8,7 +8,7 @@ export const WithRoutesInModal = withRouter(React.createClass({
     children: PropTypes.node,
     router: PropTypes.object,
     routes: PropTypes.array,
-    returnTo: PropTypes.oneOfType([
+    parentLocation: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object
     ])
@@ -33,11 +33,11 @@ export const WithRoutesInModal = withRouter(React.createClass({
     }
   },
   closeModal() {
-    const returnTo = this.props.returnTo || this.previousLocation.pathname;
-    this.props.router.push(returnTo);
+    const previousLocation = this.props.parentLocation || this.previousLocation.pathname;
+    this.props.router.push(previousLocation);
   },
   render() {
-    if (this.props.returnTo) {
+    if (this.props.parentLocation) {
       const showModal = this.props.routes.length > 1;
       return (
         <this.props.component

--- a/src/react-router/WithRoutesInModal.js
+++ b/src/react-router/WithRoutesInModal.js
@@ -1,13 +1,9 @@
 import React, { PropTypes } from 'react';
 import withRouter from 'react-router/lib/withRouter';
-import { Modal as DefaultModal } from '../Modal';
-import { Page as DefaultPage } from '../Page';
 
 export const WithRoutesInModal = withRouter(React.createClass({
   propTypes: {
     component: PropTypes.func,
-    modal: PropTypes.func,
-    page: PropTypes.func,
     location: PropTypes.object.isRequired,
     children: PropTypes.node,
     router: PropTypes.object,
@@ -20,10 +16,6 @@ export const WithRoutesInModal = withRouter(React.createClass({
   getInitialState: () => ({
     pageLocked: false
   }),
-  componentWillMount() {
-    this.Modal = this.props.modal || DefaultModal;
-    this.Page = this.props.page || DefaultPage;
-  },
   componentWillReceiveProps(nextProps) {
     if (
       // modal requested
@@ -44,32 +36,15 @@ export const WithRoutesInModal = withRouter(React.createClass({
     const returnTo = this.props.returnTo || this.previousLocation.pathname;
     this.props.router.push(returnTo);
   },
-  lockPage() {
-    this.setState({ pageLocked: true });
-  },
-  unlockPage() {
-    this.setState({ pageLocked: false });
-  },
   render() {
-    const modal = (open) => (
-      <this.Modal
-        open={open}
-        onRequestClose={this.closeModal}
-        onBeforeOpen={this.lockPage}
-        onBeforeClose={this.unlockPage}>
-        {this.props.children}
-      </this.Modal>
-    );
-
     if (this.props.returnTo) {
       const showModal = this.props.routes.length > 1;
       return (
-        <div>
-          <this.Page locked={this.state.pageLocked}>
-            <this.props.component />
-          </this.Page>
-          {modal(showModal)}
-        </div>
+        <this.props.component
+          showModal={showModal}
+          modalContent={this.props.children}
+          onModalClose={this.closeModal}
+        />
       );
     }
 
@@ -80,17 +55,15 @@ export const WithRoutesInModal = withRouter(React.createClass({
     );
 
     return (
-      <div>
-        <this.Page locked={this.state.pageLocked}>
-          <this.props.component>
-            {showModal ?
-              this.previousChildren :
-              this.props.children
-            }
-          </this.props.component>
-        </this.Page>
-        {modal(showModal)}
-      </div>
+      <this.props.component
+        showModal={showModal}
+        modalContent={this.props.children}
+        onModalClose={this.closeModal}>
+        {showModal ?
+          this.previousChildren :
+          this.props.children
+        }
+      </this.props.component>
     );
   }
 }));


### PR DESCRIPTION
This makes the `WithRoutesInModal` Component much less opinionated, more transparent and easier to integrate.
